### PR TITLE
Align runtime model dimensions with dataset metadata

### DIFF
--- a/run_main.py
+++ b/run_main.py
@@ -127,6 +127,10 @@ for ii in range(args.itr):
     vali_data, vali_loader = data_provider(args, 'val')
     test_data, test_loader = data_provider(args, 'test')
 
+    args.enc_in = train_data.enc_in
+    args.dec_in = args.enc_in
+    args.c_out = args.enc_in
+
     if args.model == 'Autoformer':
         model = Autoformer.Model(args).float()
     elif args.model == 'DLinear':


### PR DESCRIPTION
## Summary
- set the runtime encoder/decoder/output dimensions from the loaded training dataset so heads receive the correct feature size
- mirror the dataset-derived dimension into `dec_in` and `c_out` to keep Autoformer/DLinear construction consistent

## Testing
- python run_main.py --task_name long_term_forecast --is_training 1 --model_id debug --model TimeLLM --model_comment debug --data ETTm1 --features M --seq_len 96 --label_len 48 --pred_len 24 --enc_in 7 --dec_in 7 --c_out 7 --root_path ./dataset/ETT-small/ --data_path ETTm1.csv --des Exp --itr 1 --train_epochs 1 --batch_size 2 --learning_rate 0.001 --num_workers 0 *(fails: missing dataset file)*

------
https://chatgpt.com/codex/tasks/task_e_68e064cca9d8832bbb781ab52d23f137