### PR TITLE
Fix STGR dtype handling for bf16 runs

### DIFF
--- a/models/TimeLLM.py
+++ b/models/TimeLLM.py
@@ -337,14 +337,15 @@ class Model(nn.Module):
         batch = enc_out.shape[0] // n_vars
         patches = enc_out.shape[1]
         channels = enc_out.shape[2]
-        spatial_input = enc_out.view(batch, n_vars, patches, channels).to(torch.float32)
+        spatial_dtype = self.spatial_reprogrammer.input_projection.weight.dtype
+        spatial_input = enc_out.view(batch, n_vars, patches, channels).to(dtype=spatial_dtype)
 
         if self._graph_adj is None:
-            adjacency = torch.eye(n_vars, device=device, dtype=torch.float32)
+            adjacency = torch.eye(n_vars, device=device, dtype=spatial_dtype)
         elif isinstance(self._graph_adj, torch.Tensor):
-            adjacency = self._graph_adj.to(device=device, dtype=torch.float32)
+            adjacency = self._graph_adj.to(device=device, dtype=spatial_dtype)
         else:
-            adjacency = torch.tensor(self._graph_adj, dtype=torch.float32, device=device)
+            adjacency = torch.tensor(self._graph_adj, dtype=spatial_dtype, device=device)
 
         spatial_out = self.spatial_reprogrammer(spatial_input, adjacency)
         return spatial_out.view(batch * n_vars, patches, channels).to(enc_out.dtype)


### PR DESCRIPTION
## Summary
- align the spatial graph reprogrammer inputs and adjacency matrices with the module parameter dtype to avoid bf16 mismatches

## Testing
- accelerate launch --mixed_precision bf16 --num_processes 1 run_main.py ... *(fails: dataset configuration lacks numeric features for StandardScaler)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e785638c832ba99310199190e6af